### PR TITLE
libjpeg needed to build v0.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && \
         libffi-dev \
         libxml2-dev \
         libxslt1-dev \
+        libjpeg-dev \
         git \
         zlib1g-dev \
         libssl-dev && \


### PR DESCRIPTION
Added libjpeg-dev to fix the following error:
```
ValueError: --enable-jpeg requested but jpeg not found, aborting.
```