### PR TITLE
Improve Dockerfile, use alpine

### DIFF
--- a/dev-onbuild/Dockerfile
+++ b/dev-onbuild/Dockerfile
@@ -1,43 +1,23 @@
-FROM alpine:3.3
+FROM python:2.7
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV PYTHON /usr/bin/python2.7
+
+RUN apt-get update && \
+    apt-get install -qq -y --no-install-recommends \
+        libffi-dev \
+        libxml2-dev \
+        libxslt1-dev \
+        libjpeg-dev \
+        git \
+        zlib1g-dev \
+        libssl-dev && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV LANG en_US.UTF-8
-ENV MITM_VER git+https://github.com/mitmproxy/mitmproxy.git@master
+ENV LC_ALL C.UTF-8
 
-RUN apk add --no-cache \
-        git \
-        g++ \
-        py-pip \
-        libffi \
-        libffi-dev \
-        libjpeg-turbo \
-        libjpeg-turbo-dev \
-        libxml2 \
-        libxml2-dev \
-        libxslt \
-        libxslt-dev \
-        openssl \
-        openssl-dev \
-        python \
-        python-dev \
-        zlib \
-        zlib-dev \
- && adduser -u 7799 -D mitmproxy
-
-ONBUILD RUN LDFLAGS=-L/lib pip install $MITM_VER \
-    && apk del --purge \
-        git \
-        g++ \
-        libffi-dev \
-        libjpeg-turbo-dev \
-        libxml2-dev \
-        libxslt-dev \
-        openssl-dev \
-        python-dev \
-        zlib-dev \
-    && rm -rf ~/.cache/pip
-ONBUILD USER mitmproxy
-ONBUILD RUN mkdir /home/mitmproxy/.mitmproxy
-ONBUILD VOLUME /home/mitmproxy/.mitmproxy
-
-EXPOSE 8080 8081
-CMD ["mitmproxy"]
+ONBUILD ADD . /opt/mitmproxy
+ONBUILD WORKDIR /opt/mitmproxy
+ONBUILD RUN [ ! -e requirements.txt ] || pip install -r requirements.txt && \
+    rm -rf ~/.cache/pip /tmp/pip_build_root

--- a/dev-onbuild/Dockerfile
+++ b/dev-onbuild/Dockerfile
@@ -1,23 +1,43 @@
-FROM python:2.7
-
-ENV DEBIAN_FRONTEND noninteractive
-ENV PYTHON /usr/bin/python2.7
-
-RUN apt-get update && \
-    apt-get install -qq -y --no-install-recommends \
-        libffi-dev \
-        libxml2-dev \
-        libxslt1-dev \
-        libjpeg-dev \
-        git \
-        zlib1g-dev \
-        libssl-dev && \
-    rm -rf /var/lib/apt/lists/*
+FROM alpine:3.3
 
 ENV LANG en_US.UTF-8
-ENV LC_ALL C.UTF-8
+ENV MITM_VER git+https://github.com/mitmproxy/mitmproxy.git@master
 
-ONBUILD ADD . /opt/mitmproxy
-ONBUILD WORKDIR /opt/mitmproxy
-ONBUILD RUN [ ! -e requirements.txt ] || pip install -r requirements.txt && \
-    rm -rf ~/.cache/pip /tmp/pip_build_root
+RUN apk add --no-cache \
+        git \
+        g++ \
+        py-pip \
+        libffi \
+        libffi-dev \
+        libjpeg-turbo \
+        libjpeg-turbo-dev \
+        libxml2 \
+        libxml2-dev \
+        libxslt \
+        libxslt-dev \
+        openssl \
+        openssl-dev \
+        python \
+        python-dev \
+        zlib \
+        zlib-dev \
+ && adduser -u 7799 -D mitmproxy
+
+ONBUILD RUN LDFLAGS=-L/lib pip install $MITM_VER \
+    && apk del --purge \
+        git \
+        g++ \
+        libffi-dev \
+        libjpeg-turbo-dev \
+        libxml2-dev \
+        libxslt-dev \
+        openssl-dev \
+        python-dev \
+        zlib-dev \
+    && rm -rf ~/.cache/pip
+ONBUILD USER mitmproxy
+ONBUILD RUN mkdir /home/mitmproxy/.mitmproxy
+ONBUILD VOLUME /home/mitmproxy/.mitmproxy
+
+EXPOSE 8080 8081
+CMD ["mitmproxy"]

--- a/releases-onbuild/Dockerfile
+++ b/releases-onbuild/Dockerfile
@@ -2,14 +2,6 @@ FROM alpine:3.3
 
 ENV LANG=en_US.UTF-8
 
-RUN adduser -u 7799 -D mitmproxy
-
-USER mitmproxy
-RUN mkdir /home/mitmproxy/.mitmproxy
-VOLUME /home/mitmproxy/.mitmproxy
-
-USER root
-
 ONBUILD COPY requirements.txt /tmp/requirements.txt
 ONBUILD RUN apk add --no-cache \
         git \
@@ -41,8 +33,12 @@ ONBUILD RUN apk add --no-cache \
         python-dev \
         zlib-dev \
     && rm /tmp/requirements.txt \
-    && rm -rf ~/.cache/pip
+    && rm -rf ~/.cache/pip \
+    && adduser -u 7799 -D mitmproxy
+
 ONBUILD USER mitmproxy
+ONBUILD RUN mkdir /home/mitmproxy/.mitmproxy
+ONBUILD VOLUME /home/mitmproxy/.mitmproxy
 
 EXPOSE 8080 8081
 CMD ["mitmproxy"]

--- a/releases-onbuild/Dockerfile
+++ b/releases-onbuild/Dockerfile
@@ -1,9 +1,48 @@
-FROM python:2.7
-EXPOSE 8080
-EXPOSE 8081
-VOLUME /certs
-CMD /bin/bash
+FROM alpine:3.3
+
+ENV LANG=en_US.UTF-8
+
+RUN adduser -u 7799 -D mitmproxy
+
+USER mitmproxy
+RUN mkdir /home/mitmproxy/.mitmproxy
+VOLUME /home/mitmproxy/.mitmproxy
+
+USER root
+
 ONBUILD COPY requirements.txt /tmp/requirements.txt
-ONBUILD RUN [ ! -e /tmp/requirements.txt ] || \
-          pip install --no-cache-dir -r /tmp/requirements.txt && \
-          rm -rf /tmp/requirements.txt
+ONBUILD RUN apk add --no-cache \
+        git \
+        g++ \
+        py-pip \
+        libffi \
+        libffi-dev \
+        libjpeg-turbo \
+        libjpeg-turbo-dev \
+        libxml2 \
+        libxml2-dev \
+        libxslt \
+        libxslt-dev \
+        openssl \
+        openssl-dev \
+        python \
+        python-dev \
+        zlib \
+        zlib-dev \
+    && LDFLAGS=-L/lib pip install -r /tmp/requirements.txt \
+    && apk del --purge \
+        git \
+        g++ \
+        libffi-dev \
+        libjpeg-turbo-dev \
+        libxml2-dev \
+        libxslt-dev \
+        openssl-dev \
+        python-dev \
+        zlib-dev \
+    && rm /tmp/requirements.txt \
+    && rm -rf ~/.cache/pip
+ONBUILD USER mitmproxy
+
+EXPOSE 8080 8081
+CMD ["mitmproxy"]


### PR DESCRIPTION
This is my first shot at an improved Dockerfile.

- Alpine Linux as base
- mitmproxy now runs as non-root
- <s>configure version using an environment variable instead of requirements.txt</s>  
Turns out this does not work. We still need requirements.txt to specify the version.

@dweinstein: Looking at the existing stuff, why are there two different bases for release and dev?

/cc @wernight, whose mitmproxy Docker image was a great inspiration for this! :relaxed: 
